### PR TITLE
Setup default profile and connect wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Add a wallet:
 
 ```bash
 node src/index.js wallet:add MyWallet
+
+# specify profile (optional if a current profile is set)
+node src/index.js wallet:add MyWallet --profile 1
 ```
 
 List wallets:
@@ -44,7 +47,7 @@ node src/index.js pay
 
 ### Wallets
 
-- `wallet:add <name>` - Add a wallet
+- `wallet:add <name>` - Add a wallet to the current profile (use `--profile` to specify)
 - `wallet:list` - List wallets
 - `wallet:set-balance <wallet> <balance>` - Set wallet balance
 - `wallet:adjust <wallet> <amount>` - Adjust wallet balance

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -23,7 +23,8 @@ export function setupCommands(program) {
   program
     .command('wallet:add <name>')
     .description('Add a new wallet')
-    .action((name) => addWalletCommand({ name }));
+    .option('-p, --profile <profile>', 'Profile id')
+    .action((name, options) => addWalletCommand({ name, profile: options.profile }));
 
   program
     .command('wallet:list')

--- a/src/commands/wallet/add.js
+++ b/src/commands/wallet/add.js
@@ -1,6 +1,16 @@
 import { addWallet } from '../../controllers/wallet-controller.js';
+import { currentProfile } from '../../controllers/profile-controller.js';
 
-export function addWalletCommand({ name }) {
-  addWallet({ name });
+export function addWalletCommand({ name, profile }) {
+  let profileId = profile;
+  if (!profileId) {
+    const p = currentProfile();
+    profileId = p && p.id;
+  }
+  if (!profileId) {
+    console.log('Please select a profile first.');
+    return;
+  }
+  addWallet({ name, profileId });
   console.log(`Wallet '${name}' created.`);
 }

--- a/src/controllers/wallet-controller.js
+++ b/src/controllers/wallet-controller.js
@@ -6,9 +6,9 @@ import {
 } from '../models/wallet.js';
 import { getAdapter } from '../config/db.js';
 
-export function addWallet({ name }) {
+export function addWallet({ name, profileId }) {
   const db = getAdapter();
-  createWallet(db, { name });
+  createWallet(db, { name, profileId });
 }
 
 export function getWallets() {

--- a/src/models/wallet.js
+++ b/src/models/wallet.js
@@ -1,5 +1,5 @@
-export function createWallet(db, { name, balance = 0 }) {
-  db.insertWallet({ name, balance });
+export function createWallet(db, { name, balance = 0, profileId }) {
+  db.insertWallet({ name, balance, profileId });
 }
 
 export function listWallets(db) {

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -16,9 +16,11 @@ describe('SQLiteAdapter wallets', () => {
   });
 
   it('inserts and retrieves wallet', () => {
-    db.insertWallet({ name: 'Test' });
+    const profileId = db.getProfiles()[0].id;
+    db.insertWallet({ name: 'Test', profileId });
     const wallets = db.getWallets();
     expect(wallets.length).toBe(1);
     expect(wallets[0].name).toBe('Test');
+    expect(wallets[0].profile_id).toBe(profileId);
   });
 });


### PR DESCRIPTION
## Summary
- ensure SQLite DB creates a default `Personal` profile and sets it as current
- require wallets to belong to a profile
- support `--profile` option when adding wallets
- document wallet profile usage in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f17ddca28832c8d8cae13c8b145ad