### PR TITLE
Add charsm UI styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "better-sqlite3": "^11.10.0",
         "chalk": "^5.4.1",
+        "charsm": "^0.2.0",
         "commander": "^14.0.0",
         "inquirer": "^12.6.3"
       },
@@ -757,6 +758,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@makeomatic/ffi-napi": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@makeomatic/ffi-napi/-/ffi-napi-4.2.0.tgz",
+      "integrity": "sha512-f+kHcFZe65C6++JgdKgBFnlvESpLgfU0a4PsfnbaqQQTTcBPgRclT21ylRoVCktQr4ifXXTt6NLkn+mhq/CZ9A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@makeomatic/ref-napi": "^3.0.6",
+        "debug": "^4.3.7",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "^8.1.0",
+        "node-gyp-build": "^4.8.2",
+        "ref-struct-di": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@makeomatic/ref-napi": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@makeomatic/ref-napi/-/ref-napi-3.0.6.tgz",
+      "integrity": "sha512-PNAcp1M1kQPL6xYu16KCVM9oAAqGDRB4nEWgxTvYrxXpYiiit2ClomQI9umnJ7gMpG8vnaSFhFA+6XzPnWxSNQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-symbol-from-current-process-h": "^1.0.2",
+        "node-addon-api": "^7.0.0",
+        "node-gyp-build": "^4.2.1"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/@makeomatic/ref-napi/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.43.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.43.0.tgz",
@@ -1176,6 +1217,183 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@yuuang/ffi-rs-android-arm64": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-android-arm64/-/ffi-rs-android-arm64-1.2.12.tgz",
+      "integrity": "sha512-i2AFJ7WXethhzEW51bQ4Pp1z1+F/jJG086MCpBeMYn/0GFlV2nnTDUSOiIrWKdX/lAFkJ3MfuxQkkyJOzOnaSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-darwin-arm64": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.2.12.tgz",
+      "integrity": "sha512-ds6HRmZ+ehn6MK2ab6dovcQOStXnQTLJAgmYDFp1wrPBJUihH935moXMZEsFuiHga2OPMa2ozWimsddQvfmuZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-darwin-x64": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.2.12.tgz",
+      "integrity": "sha512-ahslNvC8cO9gbvaFJ4KRg8uqI2yZT2A+tzzeNb6IxNOg1afccTLg2Z8CBq53hvAo6VT6YXAcKYj90y5216W4yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-arm-gnueabihf": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm-gnueabihf/-/ffi-rs-linux-arm-gnueabihf-1.2.12.tgz",
+      "integrity": "sha512-Q9u9YKr2Ev1wLFNC3Pao+c1kDzwBn+FrEHQJdgmiByml/kbKkUhKcre/tOx3cix6VFIRk0TyKIdYZ72vKzU9Ng==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-arm64-gnu": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.2.12.tgz",
+      "integrity": "sha512-hqCi3fAcoJHkW6kWyrOHrZJnnLMmXgmOW8Q53h27Xu+3y3eVybJHz79koSkPrf+Oj7LWKbS0s+M12KAyN5cyBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-arm64-musl": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.2.12.tgz",
+      "integrity": "sha512-fLFcmu4xATqHn/mcXsqWbVi7fetVam9ZrITVCe1SAWhfiK2vgC8psuSC2YFuMgbXp2uyhErUQsKo5NLXg0zXXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-x64-gnu": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.2.12.tgz",
+      "integrity": "sha512-G1oRLgUvIzTS6F03m/IRxIA3+jLwzSAMsoGEzvXRmRJD7lNG3/tIfLG+dTeCisnpGpuVho8En2LOlYbDfss9jA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-x64-musl": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.2.12.tgz",
+      "integrity": "sha512-o/zfVLp8k0rS2NEcRZ9yy3MZjYEv15YJjKe3igE2P8eZiHZ5Wdo6MkM1sdI1jlG9QbZ1y7yyY3UvCvyUs+tWvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-arm64-msvc": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.2.12.tgz",
+      "integrity": "sha512-FuMP+7z/cnqSt6YAyceDnNW0cVUYyRvDxOuEoy7LAE8os/VFxHAqxNwpdUwKtCycrFVHwGu7eN+LKClk+gVeTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-ia32-msvc": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.2.12.tgz",
+      "integrity": "sha512-XRNb/oLfkC0N5R5iEnwGtYZado6a1bBITDJRSMl23TFX/H2sT0q+7YVSioRL9METMxVPIsFR2q1YkK3052PuBg==",
+      "cpu": [
+        "x64",
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-x64-msvc": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.2.12.tgz",
+      "integrity": "sha512-xRl780DUj4skKILL203o/A2AFi2W7sOs2UtDl0cur/sFGfaibVx8pN+Qx6PwBea7Y6/KMBkP1aCxgbmMYwCrzg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1345,6 +1563,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "license": "MIT"
     },
+    "node_modules/charsm": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/charsm/-/charsm-0.2.0.tgz",
+      "integrity": "sha512-m2/cIEaSpy1ZA2UnRoPAxj4Cqxg75B1Vv18MGdIkVMhDvywUzh5onqBXrrY+d8ycI31NmlFweqllDjxNda7FjA==",
+      "license": "ISC",
+      "dependencies": {
+        "@makeomatic/ffi-napi": "^4.2.0",
+        "@makeomatic/ref-napi": "^3.0.6",
+        "ffi-rs": "^1.2.2",
+        "ref-struct-di": "^1.1.1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -1401,7 +1631,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1579,6 +1808,25 @@
         }
       }
     },
+    "node_modules/ffi-rs": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/ffi-rs/-/ffi-rs-1.2.12.tgz",
+      "integrity": "sha512-WaaLl1/hD3mTHU8NBQvRULbzitZ0XgodEEz0djw1LlHZPiQJMkgbom2tLFRM+Vhtkj8SttwJm8ZDBOh1cx4koA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@yuuang/ffi-rs-android-arm64": "1.2.12",
+        "@yuuang/ffi-rs-darwin-arm64": "1.2.12",
+        "@yuuang/ffi-rs-darwin-x64": "1.2.12",
+        "@yuuang/ffi-rs-linux-arm-gnueabihf": "1.2.12",
+        "@yuuang/ffi-rs-linux-arm64-gnu": "1.2.12",
+        "@yuuang/ffi-rs-linux-arm64-musl": "1.2.12",
+        "@yuuang/ffi-rs-linux-x64-gnu": "1.2.12",
+        "@yuuang/ffi-rs-linux-x64-musl": "1.2.12",
+        "@yuuang/ffi-rs-win32-arm64-msvc": "1.2.12",
+        "@yuuang/ffi-rs-win32-ia32-msvc": "1.2.12",
+        "@yuuang/ffi-rs-win32-x64-msvc": "1.2.12"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1604,6 +1852,21 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==",
+      "license": "MIT"
+    },
+    "node_modules/get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "node_modules/github-from-package": {
@@ -1746,7 +2009,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -1793,6 +2055,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.4.0.tgz",
+      "integrity": "sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/once": {
@@ -1942,6 +2224,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0"
+      }
+    },
+    "node_modules/ref-struct-di/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "better-sqlite3": "^11.10.0",
     "chalk": "^5.4.1",
+    "charsm": "^0.2.0",
     "commander": "^14.0.0",
     "inquirer": "^12.6.3"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { program } from 'commander';
 import { setupCommands } from './view/terminal/index.js';
+import { initCliUI } from './view/terminal/ui.js';
 
 program
   .name('grana')
@@ -8,5 +9,7 @@ program
   .version('0.1.0');
 
 setupCommands(program);
+
+await initCliUI();
 
 program.parseAsync(process.argv);

--- a/src/view/terminal/category/list.js
+++ b/src/view/terminal/category/list.js
@@ -1,4 +1,5 @@
 import { getCategories } from '../../../controllers/category-controller.js';
+import { renderTable } from '../ui.js';
 
 export function listCategoryCommand() {
   const categories = getCategories();
@@ -6,5 +7,7 @@ export function listCategoryCommand() {
     console.log('No categories found.');
     return;
   }
-  categories.forEach(c => console.log(`${c.id}: ${c.name}`));
+  const headers = ['ID', 'Name'];
+  const rows = categories.map(c => [String(c.id), c.name]);
+  console.log(renderTable(headers, rows));
 }

--- a/src/view/terminal/payment/list.js
+++ b/src/view/terminal/payment/list.js
@@ -1,4 +1,5 @@
 import { getPayments } from '../../../controllers/payment-controller.js';
+import { renderTable } from '../ui.js';
 
 export function listPaymentCommand() {
   const payments = getPayments();
@@ -6,7 +7,12 @@ export function listPaymentCommand() {
     console.log('No payments found.');
     return;
   }
-  payments.forEach(p =>
-    console.log(`${p.id}: ${p.client} - ${p.amount} - ${p.status}`)
-  );
+  const headers = ['ID', 'Client', 'Amount', 'Status'];
+  const rows = payments.map(p => [
+    String(p.id),
+    p.client,
+    String(p.amount),
+    p.status
+  ]);
+  console.log(renderTable(headers, rows));
 }

--- a/src/view/terminal/payment/pending.js
+++ b/src/view/terminal/payment/pending.js
@@ -1,4 +1,5 @@
 import { getPayments } from '../../../controllers/payment-controller.js';
+import { renderTable } from '../ui.js';
 
 export function pendingPaymentsCommand() {
   const payments = getPayments({ status: 'Pending' });
@@ -6,7 +7,12 @@ export function pendingPaymentsCommand() {
     console.log('No pending payments.');
     return;
   }
-  payments.forEach(p =>
-    console.log(`${p.id}: ${p.client} - ${p.amount} - due ${p.due_date}`)
-  );
+  const headers = ['ID', 'Client', 'Amount', 'Due'];
+  const rows = payments.map(p => [
+    String(p.id),
+    p.client,
+    String(p.amount),
+    p.due_date
+  ]);
+  console.log(renderTable(headers, rows));
 }

--- a/src/view/terminal/profile/list.js
+++ b/src/view/terminal/profile/list.js
@@ -1,4 +1,5 @@
 import { getProfiles } from '../../../controllers/profile-controller.js';
+import { renderTable } from '../ui.js';
 
 export function listProfileCommand() {
   const profiles = getProfiles();
@@ -6,5 +7,7 @@ export function listProfileCommand() {
     console.log('No profiles found.');
     return;
   }
-  profiles.forEach(p => console.log(`${p.id}: ${p.name}`));
+  const headers = ['ID', 'Name'];
+  const rows = profiles.map(p => [String(p.id), p.name]);
+  console.log(renderTable(headers, rows));
 }

--- a/src/view/terminal/ui.js
+++ b/src/view/terminal/ui.js
@@ -1,0 +1,32 @@
+import { initLip, Lipgloss } from 'charsm';
+
+export let lip;
+
+export async function initCliUI() {
+  try {
+    const ok = await initLip();
+    if (ok) {
+      lip = new Lipgloss();
+    }
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+export function renderTable(headers, rows) {
+  if (!lip) {
+    const lines = [headers.join('\t')];
+    for (const r of rows) {
+      lines.push(r.join('\t'));
+    }
+    return lines.join('\n');
+  }
+
+  return lip.newTable({
+    data: { headers, rows },
+    table: { border: 'rounded', color: '99' },
+    header: { color: '212', bold: true },
+    rows: { even: { color: '246' } }
+  });
+}

--- a/src/view/terminal/wallet/balance.js
+++ b/src/view/terminal/wallet/balance.js
@@ -1,5 +1,5 @@
 import { getWallets } from '../../../controllers/wallet-controller.js';
-import chalk from 'chalk';
+import { renderTable } from '../ui.js';
 
 export function walletBalanceCommand() {
   const wallets = getWallets();
@@ -7,7 +7,7 @@ export function walletBalanceCommand() {
     console.log('No wallets found.');
     return;
   }
-  wallets.forEach(w => {
-    console.log(`${w.id}: ${chalk.green(w.name)} - Balance: ${w.balance}`);
-  });
+  const headers = ['ID', 'Name', 'Balance'];
+  const rows = wallets.map(w => [String(w.id), w.name, String(w.balance)]);
+  console.log(renderTable(headers, rows));
 }

--- a/src/view/terminal/wallet/list.js
+++ b/src/view/terminal/wallet/list.js
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { getWallets } from '../../../controllers/wallet-controller.js';
+import { renderTable } from '../ui.js';
 
 export function listWalletCommand() {
   const wallets = getWallets();
@@ -7,7 +7,7 @@ export function listWalletCommand() {
     console.log('No wallets found.');
     return;
   }
-  wallets.forEach(w => {
-    console.log(`${w.id}: ${chalk.green(w.name)} - Balance: ${w.balance}`);
-  });
+  const headers = ['ID', 'Name', 'Balance'];
+  const rows = wallets.map(w => [String(w.id), w.name, String(w.balance)]);
+  console.log(renderTable(headers, rows));
 }


### PR DESCRIPTION
## Summary
- integrate charsm dependency
- initialise charsm on startup
- add CLI helpers to render tables
- use renderTable for wallet list/balance commands
- extend table output to category, profile and payment list commands

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684f2c747ef0832cb622414fae3180c3