### PR TITLE
Fix cross-platform compatibility

### DIFF
--- a/src/view/terminal/ui.js
+++ b/src/view/terminal/ui.js
@@ -1,9 +1,10 @@
-import { initLip, Lipgloss } from 'charsm';
-
+// "charsm" does not support all platforms (e.g. macOS). We load it
+// dynamically so the CLI can still run where the module is unavailable.
 export let lip;
 
 export async function initCliUI() {
   try {
+    const { initLip, Lipgloss } = await import('charsm');
     const ok = await initLip();
     if (ok) {
       lip = new Lipgloss();


### PR DESCRIPTION
## Summary
- defer `charsm` import until runtime so grana-cli runs on macOS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f327d3d00832cba444359890acf04