### PR TITLE
Add fallback note for charsm table

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ Record expense interactively:
 node src/index.js pay
 ```
 
+List transactions:
+
+```bash
+node src/index.js transactions
+```
+
+This command renders a colored table using [Lipgloss](https://github.com/charmbracelet/lipgloss) via the `charsm` library:
+
+```
+╭──┬────────────┬────┬──────┬───────────┬──────────╮
+│ID│Wallet      │Type│Amount│Description│Date      │
+├──┼────────────┼────┼──────┼───────────┼──────────┤
+│1 │SampleWallet│IN  │100   │Salary     │2024-01-01│
+│2 │SampleWallet│OUT │50    │Groceries  │2024-01-02│
+╰──┴────────────┴────┴──────┴───────────┴──────────╯
+```
+
+If `charsm` fails to initialize (for example on macOS), the CLI prints a plain tab-separated table instead.
 ## Commands
 
 ### Wallets

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,9 @@ program
 
 setupCommands(program);
 
-await initCliUI();
+const uiOk = await initCliUI();
+if (!uiOk) {
+  console.log('(UI color disabled)');
+}
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
## Summary
- warn when UI color is unavailable
- mention charsm macOS limitation in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f455bf56c832caef32c57f9fccf67